### PR TITLE
Fix status bar style

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -449,7 +449,7 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
         return UIStatusBarStyleLightContent;
     }
 
-    return UIStatusBarStyleDefault;
+    return self.contentViewController.preferredStatusBarStyle;
 }
 
 - (void)setDimmingColor:(UIColor *)dimmingColor {


### PR DESCRIPTION
This fixes the status bar style of ISHPullUp when bottom view controller is collapsed.

Previously, the status bar style was always default. This causes the status bar to use a black font although a white font may be better for the current content view controller.

Now the ISHPullUpViewController returns the preferred status bar style of the content view controller.