### PR TITLE
Increase damping to avoid overshooting when animating to expanded state

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -343,7 +343,7 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
 
     [UIView animateWithDuration:0.4
                           delay:0
-         usingSpringWithDamping:0.6
+         usingSpringWithDamping:0.9
           initialSpringVelocity:0.3
                         options:UIViewAnimationOptionAllowUserInteraction
                      animations:updateBlock


### PR DESCRIPTION
This caused issues before with auto layout where the bottom view controller would often not be resized to extend up to the bottom of the screen, leaving a small gap mid-way through the animation.