### PR TITLE
Add dimming view at correct index to view

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -519,12 +519,12 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
     }
 
     // add dimming view to view hierachy
-    [self.view addSubview:dimmingView];
-    [self setDimmingView:dimmingView];
-
     if (self.bottomViewController) {
-        [self.view bringSubviewToFront:self.bottomViewController.view];
+        [self.view insertSubview:dimmingView belowSubview:self.bottomViewController.view];
+    } else {
+        [self.view addSubview:dimmingView];
     }
+    [self setDimmingView:dimmingView];
 
     // setup initial frame without animation (may be called within an animation block)
     [UIView performWithoutAnimation:^{


### PR DESCRIPTION
This fixes issues for subclasses that add custom overlays. The other locations where the view order is changed (when manipulating the view controller hierarchy) can be overridden by subclasses to change the view order if needed, although we might want to also use the more fine-grained view ordering method there instead of `bringSubviewToFront`.