### PR TITLE
Fix dimming for low maximum to minimum height differences

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.h
+++ b/ISHPullUp/ISHPullUpViewController.h
@@ -206,7 +206,9 @@ typedef NS_ENUM(NSUInteger, ISHPullUpBottomLayoutMode) {
 /// Set to nil to disable dimming. Default is black with 40% alpha.
 @property (nonatomic, nullable) UIColor *dimmingColor;
 
-/// The threshold at which the content should be dimmed relative to the maximum height. Default is 0.5.
+/// The threshold at which the content should be dimmed relative to the
+/// difference between minimum and maximum height. Default is 0.5 meaning
+/// that dimming will start half way between min and max height.
 @property (nonatomic) CGFloat dimmingThreshold;
 
 /// Returns the current model value for the height of the bottomViewController.

--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -324,8 +324,9 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
     }
     CGFloat oldHeight = self.bottomHeight;
     self.bottomHeight = bottomHeight;
-
-    BOOL dimmingViewHidden = (self.bottomHeight < self.dimmingThreshold * self.maximumBottomHeightCached);
+    CGFloat heightOverMinimum = self.bottomHeight - self.minimumBottomHeightCached;
+    CGFloat maximumHeightOverMinimum = self.maximumBottomHeightCached - self.minimumBottomHeightCached;
+    BOOL dimmingViewHidden = (heightOverMinimum < (self.dimmingThreshold * maximumHeightOverMinimum));
     void (^updateBlock)();
     updateBlock = ^{
         // setup (hide) dimming view with oldheight


### PR DESCRIPTION
The dimming view was not correctly dismissed for small maximum heights before.