### PR TITLE
Fix animation glitch when ending pan gesture in bounce area

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -344,7 +344,7 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
                           delay:0
          usingSpringWithDamping:0.9
           initialSpringVelocity:0.3
-                        options:UIViewAnimationOptionAllowUserInteraction
+                        options:UIViewAnimationOptionAllowUserInteraction | UIViewAnimationOptionLayoutSubviews
                      animations:updateBlock
                      completion:nil];
 }


### PR DESCRIPTION
This fixes an issue where the bottom content would be layout without animation and then moved down along with the bottom view.