### PR TITLE
Remove auto-generated library version accessors

### DIFF
--- a/SupportingFiles/ISHPullUp.h
+++ b/SupportingFiles/ISHPullUp.h
@@ -8,12 +8,6 @@
 
 #import <UIKit/UIKit.h>
 
-// Project version number for ISHPullUp.
-FOUNDATION_EXPORT double ISHPullUpVersionNumber;
-
-// Project version string for ISHPullUp.
-FOUNDATION_EXPORT const unsigned char ISHPullUpVersionString[];
-
 #import "ISHPullUpViewController.h"
 #import "ISHPullUpHandleView.h"
 #import "ISHPullUpRoundedView.h"


### PR DESCRIPTION
They do not work with manual installation nor with CocoaPods. To make
the umbrella header universally useful without hidden bug potential,
it's better to remove them entirely.