### PR TITLE
Respect bottom layout guide when positioning the bottom view controller

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -441,16 +441,21 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
              */
             CGFloat maxHeight = self.maximumBottomHeightCached;
             CGFloat expandedBottomHeight = MAX(maxHeight, clampedBottomHeight);
-            bottomFrame = CGRectMake(0, CGRectGetMaxY(bounds) - clampedBottomHeight, CGRectGetWidth(bounds), expandedBottomHeight);
+            CGFloat yPosition = CGRectGetMaxY(bounds) - clampedBottomHeight - self.bottomLayoutGuide.length;
+
+            bottomFrame = CGRectMake(0, yPosition, CGRectGetWidth(bounds), expandedBottomHeight);
             break;
         }
 
         case ISHPullUpBottomLayoutModeResize: {
             clampedBottomHeight = bottomHeight;
-            bottomFrame = CGRectMake(0, CGRectGetMaxY(bounds) - clampedBottomHeight, CGRectGetWidth(bounds), clampedBottomHeight);
+            CGFloat yPosition = CGRectGetMaxY(bounds) - clampedBottomHeight - self.bottomLayoutGuide.length;
+
+            bottomFrame = CGRectMake(0, yPosition, CGRectGetWidth(bounds), clampedBottomHeight);
             break;
         }
     }
+
     [self.bottomViewController.view setFrame:bottomFrame];
 
     // inform content delegate that edge insets were updated


### PR DESCRIPTION
This should fix layout/usability issues when the content controller is embedded within a tab bar controller or other container controllers.

This commit/PR is a slightly more generic version of #50 and should fix #49.
