### PR TITLE
Fixes an issue where dimming view would not be hidden on iPhone X

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -494,7 +494,7 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
 
     CGFloat maximumHeightOverMinimum = self.maximumBottomHeightCached - self.minimumBottomHeightCached;
 
-    if (!maximumHeightOverMinimum) {
+    if (maximumHeightOverMinimum <= 0) {
         // if the view cannot be extended beyond minimum always hide dimming view
         return YES;
     }


### PR DESCRIPTION
The issue occurred when toggling the hidden state of the bottom view controller if there was a positive bottom insets.