### PR TITLE
animated:NO, prevent view glitch

### DIFF
--- a/ISHPullUp/ISHPullUpHandleView.m
+++ b/ISHPullUp/ISHPullUpHandleView.m
@@ -136,4 +136,18 @@
     return bezierPath;
 }
 
++ (ISHPullUpHandleState)handleStateForPullUpState:(ISHPullUpState)state {
+    switch (state) {
+        case ISHPullUpStateDragging:
+        case ISHPullUpStateIntermediate:
+            return ISHPullUpHandleStateNeutral;
+
+        case ISHPullUpStateExpanded:
+            return ISHPullUpHandleStateDown;
+
+        case ISHPullUpStateCollapsed:
+            return ISHPullUpHandleStateUp;
+    }
+}
+
 @end

--- a/ISHPullUp/ISHPullUpHandleView.m
+++ b/ISHPullUp/ISHPullUpHandleView.m
@@ -66,13 +66,20 @@
 
     UIBezierPath *newPath = [self pathForBounds:self.bounds state:state];
 
-    NSString *keyPath = @"path";
-    CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:keyPath];
-    animation.fromValue = (id)self.shapeLayer.path;
-    self.shapeLayer.path = [newPath CGPath];
-    animation.toValue = (id)self.shapeLayer.path;
-    animation.duration = animated ? 0.35 : 0.0;
-    [self.shapeLayer addAnimation:animation forKey:keyPath];
+    if (!animated)
+    {
+        self.shapeLayer.path = [newPath CGPath];
+    }
+    else
+    {
+        NSString *keyPath = @"path";
+        CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:keyPath];
+        animation.fromValue = (id)self.shapeLayer.path;
+        self.shapeLayer.path = [newPath CGPath];
+        animation.toValue = (id)self.shapeLayer.path;
+        animation.duration = animated ? 0.35 : 0.0;
+        [self.shapeLayer addAnimation:animation forKey:keyPath];
+    }
 }
 
 - (CGSize)intrinsicContentSize {
@@ -127,20 +134,6 @@
     [bezierPath addLineToPoint:center];
     [bezierPath addLineToPoint:centerRight];
     return bezierPath;
-}
-
-+ (ISHPullUpHandleState)handleStateForPullUpState:(ISHPullUpState)state {
-    switch (state) {
-        case ISHPullUpStateDragging:
-        case ISHPullUpStateIntermediate:
-            return ISHPullUpHandleStateNeutral;
-
-        case ISHPullUpStateExpanded:
-            return ISHPullUpHandleStateDown;
-
-        case ISHPullUpStateCollapsed:
-            return ISHPullUpHandleStateUp;
-    }
 }
 
 @end


### PR DESCRIPTION
Prevent slight animation lag (and wrong positioning) when pushing a view controller containing the pullUpHandleView, where the initial state has been changed before the final frame has been determined.