### PR TITLE
Only move bottom if all other gestures failed

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -222,6 +222,13 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
     return NO;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    NSAssert(gestureRecognizer == self.panGesture, @"Unexpected gesture recognizer: %@", gestureRecognizer);
+    
+    // Prefer all other gestures over pan gesture
+    return YES;
+}
+
 #pragma mark Content and PullUp VC
 
 - (void)setContentViewController:(UIViewController *)contentViewController {


### PR DESCRIPTION
This fixes using a `UITableViewController`/`UINavigationController` as bottom controller. The `UITableViewController` has gestures like the swipe to delete gesture which should be preferred over the bottom pan gesture. The `UINavigationController` has a swipe to go back gesture which should be preferred as well.