### PR TITLE
Properly set new shape when animation disabled

### DIFF
--- a/ISHPullUp/ISHPullUpHandleView.m
+++ b/ISHPullUp/ISHPullUpHandleView.m
@@ -65,6 +65,10 @@
     _state = state;
 
     UIBezierPath *newPath = [self pathForBounds:self.bounds state:state];
+    if(!animated) {
+        self.shapeLayer.path = [newPath CGPath];
+        return;
+    }
 
     NSString *keyPath = @"path";
     CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:keyPath];


### PR DESCRIPTION
Adding an animation with `0` duration produced visual glitches.