### PR TITLE
Introduce `requireOtherGestureRecognizersToFail` flag

### DIFF
--- a/ISHPullUp/ISHPullUpViewController.h
+++ b/ISHPullUp/ISHPullUpViewController.h
@@ -229,6 +229,9 @@ typedef struct ISHPullUpAnimationConfiguration ISHPullUpAnimationConfiguration;
  */
 @property (nonatomic) CGFloat snapThreshold;
 
+/// If YES the pan gesture recognizer will require another gesture recognizers to fail. Default is YES.
+@property (nonatomic) BOOL requireOtherGestureRecognizersToFail;
+
 /// The current state of the view controller.
 @property (nonatomic, readonly) ISHPullUpState state;
 

--- a/ISHPullUp/ISHPullUpViewController.m
+++ b/ISHPullUp/ISHPullUpViewController.m
@@ -57,6 +57,7 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
     _bottomLayoutMode = ISHPullUpBottomLayoutModeShift;
     self.bottomHeight = ISHPullUpViewControllerDefaultMinimumHeight;
     self.snapToEnds = YES;
+    self.requireOtherGestureRecognizersToFail = YES;
     self.snapThreshold = ISHPullUpViewControllerDefaultSnapThreshold;
     self.topMargin = ISHPullUpViewControllerDefaultTopMargin;
     self.dimmingColor = [UIColor colorWithWhite:0 alpha:0.4];
@@ -224,9 +225,8 @@ const CGFloat ISHPullUpViewControllerDefaultTopMargin = 20.0;
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
     NSAssert(gestureRecognizer == self.panGesture, @"Unexpected gesture recognizer: %@", gestureRecognizer);
-    
-    // Prefer all other gestures over pan gesture
-    return YES;
+
+    return self.requireOtherGestureRecognizersToFail;
 }
 
 #pragma mark Content and PullUp VC


### PR DESCRIPTION
the problem:
when panning over a `UITableView` with scroll disabled the pan gesture recogniser always fails. The reason why it's happening is the system gesture recognisers that seem never fail:
`
<_UISwipeActionPanGestureRecognizer: 0x7f85fbc09d70; state = Possible; view = <UITableView 0x7f85fc016600>; target= <(action=_swipeRecognizerDidRecognize:, target=<UISwipeHandler 0x600003dede30>)>>
`

the solution:
An option to disable GRs coordination so the pan gesture is not dependent on other gestures. 